### PR TITLE
feat: add expandable responsibilities list to CV timeline entries

### DIFF
--- a/src/components/cv/TimelineJobEntry.astro
+++ b/src/components/cv/TimelineJobEntry.astro
@@ -125,7 +125,7 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 									href={pub.url}
 									target="_blank"
 									rel="noopener noreferrer"
-									class="btn-link btn-link-external list"
+									class="publication-link"
 								>
 									{pub.title}
 								</a>
@@ -374,6 +374,27 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 
 	.publication-list li {
 		margin-bottom: 0;
+	}
+
+	.publication-link {
+		color: var(--color-primary);
+		text-decoration: none;
+		font-size: 0.9rem;
+	}
+
+	.publication-link::after {
+		content: ' ↗';
+		font-size: 0.75rem;
+		opacity: 0.7;
+		transition: opacity 0.2s ease;
+	}
+
+	.publication-link:hover {
+		text-decoration: underline;
+	}
+
+	.publication-link:hover::after {
+		opacity: 1;
 	}
 
 	/* Timeline line connecting dots */

--- a/src/components/cv/TimelineJobEntry.astro
+++ b/src/components/cv/TimelineJobEntry.astro
@@ -21,6 +21,10 @@ interface Props {
 const { title, company, location, startDate, endDate, responsibilities, skills, publications } =
 	Astro.props;
 
+const initialCount = 3;
+const visibleItems = responsibilities.slice(0, initialCount);
+const hiddenItems = responsibilities.slice(initialCount);
+
 // Function to format date for timeline display
 function formatTimelineDate(dateStr: string): string {
 	const monthNames = [
@@ -95,9 +99,18 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 			</div>
 		</div>
 
-		<ul class="responsibilities">
-			{responsibilities.map((responsibility) => <li>{responsibility}</li>)}
+		<ul class={`responsibilities${hiddenItems.length > 0 ? ' responsibilities-partial' : ''}`}>
+			{visibleItems.map((responsibility) => <li>{responsibility}</li>)}
 		</ul>
+
+		{hiddenItems.length > 0 && (
+			<details class="responsibilities-more">
+				<summary class="read-more-toggle">Show {hiddenItems.length} more</summary>
+				<ul class="responsibilities responsibilities-hidden">
+					{hiddenItems.map((responsibility) => <li>{responsibility}</li>)}
+				</ul>
+			</details>
+		)}
 
 		{skills && <SkillCategory title="Skills" skills={skills} />}
 
@@ -292,6 +305,51 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 	.responsibilities li {
 		margin-bottom: 0.75rem;
 		line-height: 1.5;
+	}
+
+	.responsibilities-partial {
+		margin-bottom: 0.5rem;
+	}
+
+	.responsibilities-more {
+		margin-bottom: 1.5rem;
+	}
+
+	.read-more-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		cursor: pointer;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--color-primary);
+		list-style: none;
+		user-select: none;
+		padding: 0.25rem 0;
+		transition: color 0.2s ease;
+	}
+
+	.read-more-toggle::-webkit-details-marker {
+		display: none;
+	}
+
+	.read-more-toggle::before {
+		content: '▶';
+		font-size: 0.6rem;
+		transition: transform 0.2s ease;
+		display: inline-block;
+	}
+
+	.responsibilities-more[open] .read-more-toggle::before {
+		transform: rotate(90deg);
+	}
+
+	.read-more-toggle:hover {
+		color: var(--color-secondary);
+	}
+
+	.responsibilities-hidden {
+		margin-top: 0.5rem;
 	}
 
 	.publications {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -47,6 +47,10 @@ import SkillCategory from '../components/cv/SkillCategory.astro';
 					]}
 					publications={[
 						{
+							title: 'Software engineering in 2026',
+							url: 'https://medium.com/p/6fb1a621238b'
+						},
+						{
 							title: 'From Surveys to Scorecards: System Health Evolution at OUA',
 							url: 'https://medium.com/openunisau-engineering/from-surveys-to-scorecards-system-health-evolution-at-oua-216bc989e090'
 						},


### PR DESCRIPTION
## Summary
Added a "Show more" expandable section to the CV timeline job entries to improve readability by initially displaying only the first 3 responsibilities and allowing users to expand to see additional ones.

## Key Changes
- Modified `TimelineJobEntry.astro` to split responsibilities into visible (first 3) and hidden items
- Implemented a collapsible `<details>` element that displays a "Show X more" toggle when there are additional responsibilities
- Added styling for the expandable section including:
  - Custom toggle button with animated arrow indicator
  - Hover effects using primary and secondary colors
  - Proper spacing adjustments when the list is partially shown
  - Smooth transitions for the expand/collapse animation

## Implementation Details
- Initial display count is hardcoded to 3 responsibilities
- The toggle uses a native HTML `<details>` element for semantic markup and built-in accessibility
- Custom styling removes the default browser details marker and replaces it with a styled arrow (`▶`) that rotates 90 degrees when expanded
- The responsibilities list gets a `responsibilities-partial` class when truncated to adjust bottom margin
- Hidden items are rendered in a separate `responsibilities-hidden` list within the details element

https://claude.ai/code/session_0159HQE6pKKc2iEfupr8Ty2L