### PR TITLE
chore: use custom port 3366 for dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run the site locally, follow these steps:
    ```
 
 4. **Preview the site**:
-   - Open [http://localhost:4321](http://localhost:4321) in your browser.
+   - Open [http://localhost:3366](http://localhost:3366) in your browser.
 
 5. **Format code** (optional):
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,7 @@ export default defineConfig({
 	trailingSlash: 'never',
 	output: 'server',
 	adapter: vercel({ imageService: true }),
+	server: { port: 3366 },
 	integrations: [mdx(), sitemap()],
 	env: {
 		validateSecrets: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test';
 
 const baseURL =
 	process.env.PLAYWRIGHT_TEST_BASE_URL ||
-	(process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:4321');
+	(process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3366');
 
 export default defineConfig({
 	testDir: './tests',
@@ -26,7 +26,7 @@ export default defineConfig({
 		? undefined
 		: {
 				command: 'pnpm dev',
-				url: 'http://localhost:4321',
+				url: 'http://localhost:3366',
 				reuseExistingServer: !process.env.CI
 			}
 });


### PR DESCRIPTION
## Summary
- Set Astro dev server to run on port 3366 instead of the default 4321, for predictable local port management
- Updated Playwright config (`baseURL` and `webServer.url`) to match the new port

## Test plan
- [x] Ran `pnpm dev` and confirmed the server starts at `http://localhost:3366`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019h3isJyt9sZVuBz9RBAhHF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the local development server to use port 3366.
  * Updated automated browser testing to connect to the new local server port.
  * Preserved deployment-based testing when a hosted environment URL is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->