### PR TITLE
Redesign: One Dark visual system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+## Code review
+
+After making any set of changes, run the `/caveman-review` skill and address any warranted
+concerns before considering the work complete.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
 	},
 	markdown: {
 		shikiConfig: {
-			theme: 'github-dark',
+			theme: 'one-dark-pro',
 			wrap: true,
 			transformers: [
 				{

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"@astrojs/sitemap": "3.7.3",
 		"@astrojs/vercel": "11.0.3",
 		"@aws-sdk/client-ses": "3.1090.0",
+		"@fontsource-variable/ibm-plex-sans": "^5.3.0",
+		"@fontsource/ibm-plex-mono": "^5.3.0",
 		"astro": "7.1.1",
 		"shiki": "4.3.1"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@aws-sdk/client-ses':
         specifier: 3.1090.0
         version: 3.1090.0
+      '@fontsource-variable/ibm-plex-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       astro:
         specifier: 7.1.1
         version: 7.1.1(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.13.1)(@vercel/functions@3.6.2(@aws-sdk/credential-provider-web-identity@3.972.65))(rollup@4.61.1)
@@ -440,6 +446,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/ibm-plex-sans@5.3.0':
+    resolution: {integrity: sha512-agG8tXFEo0hD9+J7npa4vbbWult52eMLVaQ6WQRlhs/iCAojrMAoejru85W9HTVXHfyUj96KM7gp/KGAS87XaQ==}
+
+  '@fontsource/ibm-plex-mono@5.3.0':
+    resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2825,6 +2837,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource-variable/ibm-plex-sans@5.3.0': {}
+
+  '@fontsource/ibm-plex-mono@5.3.0': {}
 
   '@img/colour@1.1.0':
     optional: true

--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -124,9 +124,7 @@ const {
 		border-bottom: none;
 		background-color: var(--color-background-alt);
 		border-radius: var(--radius-lg);
-		box-shadow:
-			0 4px 6px -1px rgba(0, 0, 0, 0.1),
-			0 2px 4px -1px rgba(0, 0, 0, 0.06);
+		box-shadow: var(--shadow-card);
 	}
 
 	.project-section:last-child {
@@ -165,7 +163,7 @@ const {
 
 	.screenshot {
 		border-radius: var(--radius-md);
-		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+		box-shadow: var(--shadow-lg);
 		transition: transform 0.3s ease;
 	}
 
@@ -274,7 +272,7 @@ const {
 	}
 
 	.secondary:hover {
-		background: var(--color-bg-secondary);
+		background: var(--color-background-hover);
 		color: var(--color-text);
 	}
 

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -38,6 +38,14 @@ const { slug, title, heroStatement, image } = Astro.props;
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
+		transition:
+			border-color 0.2s ease,
+			box-shadow 0.2s ease;
+	}
+
+	.project-card:hover {
+		border-color: var(--color-primary);
+		box-shadow: var(--shadow-card-hover);
 	}
 
 	.card-image {

--- a/src/components/Tags.astro
+++ b/src/components/Tags.astro
@@ -20,25 +20,24 @@ const { tags } = Astro.props;
 	}
 
 	.tag {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
 		background-color: var(--color-secondary-light);
 		color: var(--color-secondary);
-		padding: 0.25rem 0.75rem;
-		border-radius: var(--radius-md);
-		font-size: 0.85rem;
-		font-weight: bold;
+		padding: 0.3rem 0.7rem;
+		border-radius: 999px;
+		border: 1px solid var(--color-border);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
 	}
 
-	@media (prefers-color-scheme: dark) {
-		.tag {
-			background-color: var(--color-secondary-dark);
-			color: var(--color-secondary);
-			border: 1px solid rgba(126, 207, 154, 0.3);
-		}
-	}
-
-	:global([data-theme='dark']) .tag {
-		background-color: var(--color-secondary-dark);
-		color: var(--color-secondary);
-		border: 1px solid rgba(126, 207, 154, 0.3);
+	.tag::before {
+		content: '';
+		width: 6px;
+		height: 6px;
+		flex-shrink: 0;
+		border-radius: 50%;
+		background-color: currentColor;
 	}
 </style>

--- a/src/components/cv/Section.astro
+++ b/src/components/cv/Section.astro
@@ -13,7 +13,7 @@ const { title } = Astro.props;
 
 <style>
 	.cv-section {
-		margin-bottom: 3rem;
+		margin-bottom: var(--space-2xl);
 	}
 
 	h2 {

--- a/src/components/cv/TimelineJobEntry.astro
+++ b/src/components/cv/TimelineJobEntry.astro
@@ -21,6 +21,8 @@ interface Props {
 const { title, company, location, startDate, endDate, responsibilities, skills, publications } =
 	Astro.props;
 
+const isCurrent = !endDate || endDate === 'Present';
+
 const initialCount = 3;
 const visibleItems = responsibilities.slice(0, initialCount);
 const hiddenItems = responsibilities.slice(initialCount);
@@ -68,7 +70,7 @@ const endDisplay = endDate ? formatTimelineDate(endDate) : formatTimelineDate('P
 const dateRange = `${startDisplay} - ${endDisplay}`;
 ---
 
-<div class="timeline-item">
+<div class={`timeline-item${isCurrent ? ' is-current' : ''}`}>
 	<!-- Timeline marker - only visible on larger screens -->
 	<div class="timeline-marker">
 		<div class="timeline-dot"></div>
@@ -103,14 +105,18 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 			{visibleItems.map((responsibility) => <li>{responsibility}</li>)}
 		</ul>
 
-		{hiddenItems.length > 0 && (
-			<details class="responsibilities-more">
-				<summary class="read-more-toggle">Show {hiddenItems.length} more</summary>
-				<ul class="responsibilities responsibilities-hidden">
-					{hiddenItems.map((responsibility) => <li>{responsibility}</li>)}
-				</ul>
-			</details>
-		)}
+		{
+			hiddenItems.length > 0 && (
+				<details class="responsibilities-more">
+					<summary class="read-more-toggle">Show {hiddenItems.length} more</summary>
+					<ul class="responsibilities responsibilities-hidden">
+						{hiddenItems.map((responsibility) => (
+							<li>{responsibility}</li>
+						))}
+					</ul>
+				</details>
+			)
+		}
 
 		{skills && <SkillCategory title="Skills" skills={skills} />}
 
@@ -142,7 +148,7 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 	.timeline-item {
 		position: relative;
 		display: flex;
-		margin-bottom: 3rem;
+		margin-bottom: var(--space-xl);
 		padding-left: 0;
 	}
 
@@ -156,14 +162,18 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 	}
 
 	.timeline-dot {
-		width: 16px;
-		height: 16px;
-		background-color: var(--color-secondary);
+		width: 14px;
+		height: 14px;
+		background-color: var(--color-background);
 		border-radius: 50%;
-		border: 3px solid var(--color-background);
-		box-shadow: 0 0 0 3px var(--color-secondary);
+		border: 2px solid var(--color-primary);
 		z-index: 2;
 		margin-bottom: 0.5rem;
+	}
+
+	.is-current .timeline-dot {
+		border-color: var(--color-accent);
+		box-shadow: 0 0 0 3px var(--color-accent-light);
 	}
 
 	.timeline-date {
@@ -179,12 +189,17 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 	}
 
 	.timeline-range {
+		font-family: var(--font-mono);
 		font-size: 0.75rem;
-		font-weight: 600;
-		color: var(--color-secondary);
+		font-weight: 500;
+		color: var(--color-text-light);
 		text-transform: uppercase;
-		letter-spacing: 0.5px;
+		letter-spacing: 0.05em;
 		white-space: nowrap;
+	}
+
+	.is-current .timeline-range {
+		color: var(--color-accent);
 	}
 
 	.timeline-content {
@@ -404,9 +419,9 @@ const dateRange = `${startDisplay} - ${endDisplay}`;
 		top: 20px;
 		left: 50%;
 		transform: translateX(-50%);
-		width: 2px;
-		height: calc(100% + 3rem);
-		background: linear-gradient(to bottom, var(--color-secondary) 0%, var(--color-secondary) 100%);
+		width: 1px;
+		height: calc(100% + var(--space-xl));
+		background: var(--color-border);
 		z-index: 1;
 	}
 

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -42,7 +42,7 @@ const { frontmatter } = Astro.props;
 
 <style>
 	header {
-		margin-bottom: 3rem;
+		margin-bottom: var(--space-2xl);
 	}
 
 	.post-meta {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,8 @@
 ---
+import '@fontsource-variable/ibm-plex-sans/wght.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@fontsource/ibm-plex-mono/600.css';
 import '../styles/global.css';
 import GoogleAnalytics from '../components/GoogleAnalytics.astro';
 import LoadingIndicator from '../components/LoadingIndicator.astro';
@@ -48,8 +52,6 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 		<meta name="twitter:title" content={title} />
 		<meta name="twitter:description" content={description} />
 
-		<link rel="preconnect" href="https://fonts.googleapis.com" />
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link rel="sitemap" href="/sitemap-index.xml" />
 		<link rel="alternate" type="application/rss+xml" title="Dejan Vasic - Blog" href="/rss.xml" />
 		<GoogleAnalytics />
@@ -78,10 +80,12 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 		<LoadingIndicator />
 		<header class="site-header">
 			<div class="header-container">
+				<a href="/" class="wordmark" aria-label="dejan.vasic — home">dejan<span>.</span>vasic</a>
 				<nav class="main-nav">
 					<a href="/" class={normalizedPathname === '' ? 'active' : ''}>Home</a>
 					<a href="/cv" class={normalizedPathname === '/cv' ? 'active' : ''}>CV</a>
-					<a href="/projects" class={normalizedPathname.startsWith('/projects') ? 'active' : ''}>Projects</a
+					<a href="/projects" class={normalizedPathname.startsWith('/projects') ? 'active' : ''}
+						>Projects</a
 					>
 					<a href="/blog" class={normalizedPathname === '/blog' ? 'active' : ''}>Blog</a>
 					<ThemeToggle />
@@ -144,7 +148,7 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 	}
 
 	.main-nav a.active {
-		border-bottom: 3px solid var(--color-primary);
+		border-bottom: 2px solid var(--color-primary);
 	}
 
 	.main-nav a:not(.active):hover {
@@ -160,8 +164,11 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 	}
 
 	.site-header {
+		position: sticky;
+		top: 0;
+		z-index: 40;
 		border-bottom: 1px solid var(--color-border);
-		padding: 1rem 0;
+		padding: 1.25rem 0;
 		background-color: var(--color-background);
 	}
 
@@ -212,12 +219,13 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 	@media (max-width: 768px) {
 		.main-nav {
 			justify-content: center;
+			flex-wrap: wrap;
 		}
 
 		.header-container,
 		.footer-container {
 			flex-direction: column;
-			gap: 1rem;
+			gap: 0.75rem;
 			text-align: center;
 		}
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -87,7 +87,7 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 					<a href="/projects" class={normalizedPathname.startsWith('/projects') ? 'active' : ''}
 						>Projects</a
 					>
-					<a href="/blog" class={normalizedPathname === '/blog' ? 'active' : ''}>Blog</a>
+					<a href="/blog" class={normalizedPathname.startsWith('/blog') ? 'active' : ''}>Blog</a>
 					<ThemeToggle />
 				</nav>
 			</div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -47,12 +47,14 @@ const sortedPosts = allPosts.sort((a, b) => {
 			{
 				sortedPosts.map((post) => (
 					<article class="post-card">
-						<div class="post-date">{post.frontmatter.date}</div>
+						<div class="post-meta">
+							<span class="post-date">{post.frontmatter.date}</span>
+							<Tags tags={post.frontmatter.tags?.map((t: string) => t)} />
+						</div>
 						<h2>
 							<a href={post.url}>{post.frontmatter.title}</a>
 						</h2>
 						<p class="excerpt">{post.frontmatter.excerpt}</p>
-						<Tags tags={post.frontmatter.tags?.map((t: string) => t)} />
 						<a href={post.url} class="btn-link small">
 							Read post →
 						</a>
@@ -93,7 +95,7 @@ const sortedPosts = allPosts.sort((a, b) => {
 	.rss-link:hover {
 		color: var(--color-primary);
 		border-color: var(--color-primary);
-		background-color: var(--color-bg-secondary);
+		background-color: var(--color-background-hover);
 	}
 
 	.rss-link svg {
@@ -102,26 +104,44 @@ const sortedPosts = allPosts.sort((a, b) => {
 
 	.intro {
 		color: var(--color-text-light);
-		margin-bottom: 3rem;
+		margin-bottom: var(--space-2xl);
 		font-size: 1.2rem;
 		font-weight: 400;
 	}
 
 	.posts {
 		display: grid;
-		gap: 2.5rem;
+		gap: var(--space-xl);
 		margin-bottom: 3rem;
 	}
 
 	.post-card {
-		padding-bottom: 2rem;
-		border-bottom: 1px solid var(--color-border);
+		padding: var(--space-lg);
+		margin: 0 calc(var(--space-lg) * -1);
+		border-left: 2px solid transparent;
+		border-radius: var(--radius-md);
+		transition:
+			border-color 0.15s ease,
+			background-color 0.15s ease;
+	}
+
+	.post-card:hover {
+		border-left-color: var(--color-primary);
+		background-color: var(--color-background-hover);
+	}
+
+	.post-meta {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: var(--space-md);
+		margin-bottom: var(--space-sm);
 	}
 
 	.post-date {
+		font-family: var(--font-mono);
 		color: var(--color-text-light);
-		font-size: 0.9rem;
-		margin-bottom: 0.5rem;
+		font-size: 0.85rem;
 	}
 
 	.post-card h2 {
@@ -142,20 +162,5 @@ const sortedPosts = allPosts.sort((a, b) => {
 		color: var(--color-text-light);
 		line-height: 1.6;
 		margin-bottom: 1rem;
-	}
-
-	.read-more {
-		/* Styles now handled by .btn-link class in global.css */
-	}
-
-	.tag {
-		display: inline-block;
-		background-color: var(--color-bg-secondary);
-		color: var(--color-text-light);
-		font-size: 0.8rem;
-		padding: 0.25rem 0.75rem;
-		border-radius: var(--radius-lg);
-		margin-right: 0.5rem;
-		margin-bottom: 0.5rem;
 	}
 </style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -118,16 +118,16 @@ const sortedPosts = allPosts.sort((a, b) => {
 	.post-card {
 		padding: var(--space-lg);
 		margin: 0 calc(var(--space-lg) * -1);
-		border-left: 2px solid transparent;
+		border: 1px solid transparent;
 		border-radius: var(--radius-md);
 		transition:
 			border-color 0.15s ease,
-			background-color 0.15s ease;
+			box-shadow 0.15s ease;
 	}
 
 	.post-card:hover {
-		border-left-color: var(--color-primary);
-		background-color: var(--color-background-hover);
+		border-color: var(--color-primary);
+		box-shadow: var(--shadow-card-hover);
 	}
 
 	.post-meta {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -279,16 +279,9 @@ import SkillCategory from '../components/cv/SkillCategory.astro';
 		padding-left: 0;
 	}
 
-	/* Optional: Add some spacing for the Work Experience section */
 	:global(.cv-section h2) {
 		background-color: var(--color-background);
 		padding: 1rem 0;
 		margin-bottom: 2rem;
-	}
-
-	@media (prefers-color-scheme: dark) {
-		:global(.cv-section h2) {
-			background-color: var(--color-background);
-		}
 	}
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,9 +35,10 @@ import Layout from '../layouts/Layout.astro';
 
 		<div class="contact-box">
 			<p>
-				Have a project in mind? I'm available for freelance work, consulting, and long-term contracts.
+				Have a project in mind? I'm available for freelance work, consulting, and long-term
+				contracts.
 			</p>
-			<a href="/contact" class="btn-link">Get in Touch</a>
+			<a href="/contact" class="btn-link primary">Get in Touch</a>
 		</div>
 
 		<nav class="page-nav">
@@ -54,16 +55,8 @@ import Layout from '../layouts/Layout.astro';
 		margin-bottom: 0.5rem;
 	}
 
-	h2 {
-		font-size: 1.5rem;
-		color: var(--color-text-light);
-		margin-bottom: 2rem;
-		font-weight: 500;
-	}
-
 	.content {
-		line-height: 1.6;
-		margin-bottom: 2rem;
+		margin-bottom: var(--space-lg);
 	}
 
 	.hero {
@@ -77,33 +70,26 @@ import Layout from '../layouts/Layout.astro';
 			width: 150px;
 			height: 150px;
 			border-radius: 50%;
-			box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+			box-shadow: var(--shadow-md);
 		}
 	}
 
 	.contact-box {
-		padding: 2rem 0;
-		margin: 2rem 0;
-	}
-
-	.contact-box h2 {
-		color: var(--color-primary-dark);
-		margin-bottom: 0.75rem;
-		font-size: 1.75rem;
+		padding: var(--space-xl) 0;
+		margin: var(--space-md) 0;
 	}
 
 	.contact-box p {
 		color: var(--color-text-light);
 		margin-bottom: 1.5rem;
-		line-height: 1.6;
 	}
 
 	.page-nav {
 		display: flex;
-		gap: 2rem;
-		margin-top: 3rem;
+		gap: 1.5rem;
+		margin-top: var(--space-xl);
 		border-top: 1px solid var(--color-border);
-		padding-top: 2rem;
+		padding-top: var(--space-lg);
 		flex-wrap: wrap;
 	}
 
@@ -112,5 +98,4 @@ import Layout from '../layouts/Layout.astro';
 			margin-bottom: var(--space-lg);
 		}
 	}
-
 </style>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -28,7 +28,7 @@ import { projects } from '../../content/projects';
 <style>
 	.intro {
 		color: var(--color-text-light);
-		margin-bottom: 3rem;
+		margin-bottom: var(--space-2xl);
 		font-size: 1.2rem;
 		font-weight: 400;
 	}
@@ -36,7 +36,7 @@ import { projects } from '../../content/projects';
 	.projects-list {
 		display: grid;
 		grid-template-columns: 1fr;
-		gap: 1.25rem;
+		gap: var(--space-lg);
 		margin-bottom: 3rem;
 	}
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,4 @@
-/* Global CSS file for Astro 5 portfolio site */
-
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap');
+/* Global CSS file for Astro 7 portfolio site */
 
 /* Base styles */
 * {
@@ -12,40 +10,37 @@
 :root {
 	/* Typography */
 	--font-sans:
-		'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-		'Open Sans', 'Helvetica Neue', sans-serif;
+		'IBM Plex Sans Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+		Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 	--font-mono:
-		'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, Monaco, 'Liberation Mono',
-		'Courier New', monospace;
+		'IBM Plex Mono', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, Monaco,
+		'Liberation Mono', 'Courier New', monospace;
+	--font-heading: var(--font-mono);
 
-	/* Colors */
-	--color-primary: #3b6fa0;
-	--color-secondary: #6db58a;
-	--color-primary-dark: #2d5a82;
-	--color-primary-light: #e4eef8;
-	--color-secondary-light: #e8f5ee;
-	--color-accent: #c9a84c;
-	--color-accent-light: #faf3e0;
+	/* Colors — One Light */
+	--color-primary: #4078f2;
+	--color-primary-dark: #2f5fd1;
+	--color-primary-light: rgba(64, 120, 242, 0.08);
+	--color-secondary: #50a14f;
+	--color-secondary-light: #e9f5e8;
+	--color-accent: #986801;
+	--color-accent-light: #fbf2e2;
+	--color-accent-contrast: #fffaf0;
 
 	/* Status colors */
-	--color-success: #2d7a5f;
-	--color-success-bg: #ecf9f4;
-	--color-success-border: #b8e6d5;
-	--color-error: #b91c1c;
-	--color-error-bg: #fef2f2;
-	--color-error-border: #fecaca;
+	--color-success: #50a14f;
+	--color-success-bg: #eaf6e9;
+	--color-success-border: #cbe8c9;
+	--color-error: #e45649;
+	--color-error-bg: #fdecea;
+	--color-error-border: #f7c8c3;
 
-	--color-dark-hover: #334155;
-	--color-dark-border: #334155;
-	--color-dark-text: #e2e8f0;
-	--color-dark-loading: #475569;
-
-	--color-text: #0f172a;
-	--color-text-light: #475569;
-	--color-background: #f5f5f7;
-	--color-background-hover: #e0e0e2;
-	--color-background-alt: #e0e0e2;
-	--color-border: #d1d5db;
+	--color-text: #383a42;
+	--color-text-light: #696c77;
+	--color-background: #fafafa;
+	--color-background-hover: #eeeeef;
+	--color-background-alt: #ffffff;
+	--color-border: #e2e2e4;
 
 	/* Spacing */
 	--space-xs: 0.25rem;
@@ -53,107 +48,113 @@
 	--space-md: 1rem;
 	--space-lg: 2rem;
 	--space-xl: 4rem;
+	--space-2xl: 6rem;
 
 	/* Shadows */
-	--shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.1);
-	--shadow-md: 0 4px 6px rgba(15, 23, 42, 0.1);
-	--shadow-lg: 0 10px 15px -3px rgba(15, 23, 42, 0.1);
-	--shadow-card: 0 4px 12px rgba(0, 0, 0, 0.1);
-	--shadow-card-hover: 0 12px 24px rgba(0, 0, 0, 0.15);
+	--shadow-sm: 0 1px 2px rgba(56, 58, 66, 0.06);
+	--shadow-md: 0 4px 10px rgba(56, 58, 66, 0.08);
+	--shadow-lg: 0 10px 24px rgba(56, 58, 66, 0.08);
+	--shadow-card: 0 1px 2px rgba(56, 58, 66, 0.05), 0 8px 20px rgba(56, 58, 66, 0.06);
+	--shadow-card-hover: 0 4px 10px rgba(56, 58, 66, 0.08), 0 16px 32px rgba(56, 58, 66, 0.1);
 
 	/* Border radius */
-	--radius-sm: 0.5rem;
-	--radius-md: 0.75rem;
-	--radius-lg: 1.5rem;
+	--radius-sm: 0.375rem;
+	--radius-md: 0.625rem;
+	--radius-lg: 1rem;
 
 	color-scheme: light;
 }
 
 [data-theme='light'] {
-	--color-primary: #3b6fa0;
-	--color-secondary: #6db58a;
-	--color-primary-dark: #2d5a82;
-	--color-primary-light: #e4eef8;
-	--color-secondary-light: #e8f5ee;
-	--color-accent: #c9a84c;
-	--color-accent-light: #faf3e0;
+	--color-primary: #4078f2;
+	--color-primary-dark: #2f5fd1;
+	--color-primary-light: rgba(64, 120, 242, 0.08);
+	--color-secondary: #50a14f;
+	--color-secondary-light: #e9f5e8;
+	--color-accent: #986801;
+	--color-accent-light: #fbf2e2;
+	--color-accent-contrast: #fffaf0;
 
-	/* Status colors */
-	--color-success: #2d7a5f;
-	--color-success-bg: #ecf9f4;
-	--color-success-border: #b8e6d5;
-	--color-error: #b91c1c;
-	--color-error-bg: #fef2f2;
-	--color-error-border: #fecaca;
+	--color-success: #50a14f;
+	--color-success-bg: #eaf6e9;
+	--color-success-border: #cbe8c9;
+	--color-error: #e45649;
+	--color-error-bg: #fdecea;
+	--color-error-border: #f7c8c3;
 
-	--color-dark-hover: #334155;
-	--color-dark-border: #334155;
-	--color-dark-text: #e2e8f0;
-	--color-dark-loading: #475569;
-
-	--color-text: #0f172a;
-	--color-text-light: #475569;
-	--color-background: #f5f5f7;
-	--color-background-hover: #e0e0e2;
-	--color-background-alt: #fff;
-	--color-border: #d1d5db;
+	--color-text: #383a42;
+	--color-text-light: #696c77;
+	--color-background: #fafafa;
+	--color-background-hover: #eeeeef;
+	--color-background-alt: #ffffff;
+	--color-border: #e2e2e4;
 
 	color-scheme: light;
 }
 
 [data-theme='dark'] {
+	--color-primary: #61afef;
+	--color-primary-dark: #4d9be0;
+	--color-primary-light: rgba(97, 175, 239, 0.12);
+	--color-secondary: #98c379;
+	--color-secondary-light: rgba(152, 195, 121, 0.12);
+	--color-accent: #e5c07b;
+	--color-accent-light: rgba(229, 192, 123, 0.12);
+	--color-accent-contrast: #23262d;
+
+	--color-success: #98c379;
+	--color-success-bg: rgba(152, 195, 121, 0.14);
+	--color-success-border: rgba(152, 195, 121, 0.3);
+	--color-error: #e06c75;
+	--color-error-bg: rgba(224, 108, 117, 0.14);
+	--color-error-border: rgba(224, 108, 117, 0.3);
+
 	--color-background: #282c34;
-	--color-background-hover: #3c424a;
-	--color-background-alt: #3c424a;
-	--color-text: #fff;
-	--color-text-light: #e2e8f0;
-	--color-border: hsl(213, 12%, 30%);
+	--color-background-hover: #333842;
+	--color-background-alt: #2c313c;
+	--color-text: #abb2bf;
+	--color-text-light: #7f848e;
+	--color-border: #3b4048;
 
-	/* More vibrant primary colors for dark mode */
-	--color-primary: #5a9abf;
-	--color-primary-dark: #4a85a8;
-	--color-primary-light: rgba(90, 154, 191, 0.1);
-	--color-secondary: #7ecf9a;
-	--color-secondary-dark: #1e3a2a;
-	--color-accent: #d4b95f;
-	--color-accent-light: rgba(212, 185, 95, 0.1);
-
-	/* Status colors */
-	--color-success: #5fd4a9;
-	--color-success-bg: rgba(95, 212, 169, 0.15);
-	--color-success-border: rgba(95, 212, 169, 0.3);
-	--color-error: #f87171;
-	--color-error-bg: rgba(248, 113, 113, 0.15);
-	--color-error-border: rgba(248, 113, 113, 0.3);
+	--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+	--shadow-md: 0 4px 10px rgba(0, 0, 0, 0.3);
+	--shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.35);
+	--shadow-card: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 20px rgba(0, 0, 0, 0.28);
+	--shadow-card-hover: 0 4px 12px rgba(0, 0, 0, 0.3), 0 18px 36px rgba(0, 0, 0, 0.4);
 
 	color-scheme: dark;
 }
 
 @media (prefers-color-scheme: dark) {
 	[data-theme='system'] {
+		--color-primary: #61afef;
+		--color-primary-dark: #4d9be0;
+		--color-primary-light: rgba(97, 175, 239, 0.12);
+		--color-secondary: #98c379;
+		--color-secondary-light: rgba(152, 195, 121, 0.12);
+		--color-accent: #e5c07b;
+		--color-accent-light: rgba(229, 192, 123, 0.12);
+		--color-accent-contrast: #23262d;
+
+		--color-success: #98c379;
+		--color-success-bg: rgba(152, 195, 121, 0.14);
+		--color-success-border: rgba(152, 195, 121, 0.3);
+		--color-error: #e06c75;
+		--color-error-bg: rgba(224, 108, 117, 0.14);
+		--color-error-border: rgba(224, 108, 117, 0.3);
+
 		--color-background: #282c34;
-		--color-background-hover: #3c424a;
-		--color-background-alt: #3c424a;
-		--color-text: #fff;
-		--color-text-light: #e2e8f0;
-		--color-border: hsl(213, 12%, 30%);
+		--color-background-hover: #333842;
+		--color-background-alt: #2c313c;
+		--color-text: #abb2bf;
+		--color-text-light: #7f848e;
+		--color-border: #3b4048;
 
-		/* More vibrant primary colors for dark mode */
-		--color-primary: #5a9abf;
-		--color-primary-dark: #4a85a8;
-		--color-primary-light: rgba(90, 154, 191, 0.1);
-		--color-secondary: #7ecf9a;
-		--color-secondary-dark: #1e3a2a;
-		--color-accent: #d4b95f;
-		--color-accent-light: rgba(212, 185, 95, 0.1);
-
-		/* Status colors */
-		--color-success: #5fd4a9;
-		--color-success-bg: rgba(95, 212, 169, 0.15);
-		--color-success-border: rgba(95, 212, 169, 0.3);
-		--color-error: #f87171;
-		--color-error-bg: rgba(248, 113, 113, 0.15);
-		--color-error-border: rgba(248, 113, 113, 0.3);
+		--shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+		--shadow-md: 0 4px 10px rgba(0, 0, 0, 0.3);
+		--shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.35);
+		--shadow-card: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 20px rgba(0, 0, 0, 0.28);
+		--shadow-card-hover: 0 4px 12px rgba(0, 0, 0, 0.3), 0 18px 36px rgba(0, 0, 0, 0.4);
 
 		color-scheme: dark;
 	}
@@ -164,7 +165,7 @@ html {
 	color: var(--color-text);
 	background-color: var(--color-background);
 	font-size: 16px;
-	line-height: 1.5;
+	line-height: 1.7;
 }
 
 body {
@@ -179,15 +180,17 @@ h3,
 h4,
 h5,
 h6 {
-	line-height: 1.2;
+	font-family: var(--font-heading);
+	line-height: 1.25;
 	font-weight: 600;
+	letter-spacing: -0.01em;
 }
 
 h1 {
 	font-size: 2.5rem;
 	margin-bottom: var(--space-lg);
-	font-weight: 700;
-	letter-spacing: -0.5px;
+	font-weight: 600;
+	letter-spacing: -0.02em;
 }
 
 h2 {
@@ -213,6 +216,12 @@ a {
 a:hover {
 	color: var(--color-primary-dark);
 	text-decoration: underline;
+}
+
+a:focus-visible,
+button:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 3px;
 }
 
 img {
@@ -257,15 +266,33 @@ li {
 	margin: 0 auto;
 	padding: 0 var(--space-lg);
 	display: flex;
-	justify-content: end;
+	justify-content: space-between;
 	align-items: center;
 }
 
+.wordmark {
+	font-family: var(--font-heading);
+	font-weight: 600;
+	font-size: 0.95rem;
+	letter-spacing: 0.01em;
+	color: var(--color-text);
+}
+
+.wordmark:hover {
+	color: var(--color-text);
+	text-decoration: none;
+}
+
+.wordmark span {
+	color: var(--color-primary);
+}
+
 .logo {
-	font-weight: 700;
+	font-family: var(--font-heading);
+	font-weight: 600;
 	font-size: 1.5rem;
 	color: var(--color-text);
-	letter-spacing: -0.5px;
+	letter-spacing: -0.01em;
 }
 
 .social-links {
@@ -290,20 +317,33 @@ li {
 	font-weight: 500;
 	padding: 0.75rem 1.5rem;
 	border-radius: var(--radius-md);
-	background: linear-gradient(135deg, var(--color-primary-light), rgba(255, 255, 255, 0.05));
-	border: 1px solid var(--color-primary);
+	background: transparent;
+	border: 1px solid var(--color-border);
 	color: var(--color-text);
-	transition: all 0.3s ease;
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	transition: all 0.2s ease;
 	font-size: 1rem;
 }
 
 .btn-link:hover {
-	box-shadow: 0 4px 12px rgba(59, 111, 160, 0.3);
-	background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-	color: white;
-	border-color: var(--color-primary-dark);
+	border-color: var(--color-primary);
+	color: var(--color-primary);
+	background: var(--color-background-hover);
 	text-decoration: none;
+}
+
+/* Primary variant — reserved for the one true call-to-action per page */
+.btn-link.primary {
+	background: var(--color-accent);
+	border-color: var(--color-accent);
+	color: var(--color-accent-contrast);
+	box-shadow: var(--shadow-card);
+}
+
+.btn-link.primary:hover {
+	background: var(--color-accent);
+	color: var(--color-accent-contrast);
+	filter: brightness(1.08);
+	box-shadow: var(--shadow-card-hover);
 }
 
 /* External link indicator - only adds the arrow */
@@ -333,19 +373,6 @@ li {
 	text-align: left;
 }
 
-@media (prefers-color-scheme: dark) {
-	.btn-link {
-		background: linear-gradient(135deg, var(--color-primary-light), rgba(90, 154, 191, 0.05));
-		border-color: var(--color-primary);
-		color: var(--color-text);
-	}
-
-	.btn-link:hover {
-		background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
-		box-shadow: 0 4px 12px rgba(90, 154, 191, 0.4);
-	}
-}
-
 @media (max-width: 768px) {
 	.btn-link {
 		padding: 0.65rem 1.25rem;
@@ -366,7 +393,7 @@ pre {
 	padding: var(--space-lg);
 	border-radius: var(--radius-md);
 	overflow-x: auto;
-	background-color: #1e1e1e;
+	background-color: var(--color-background-alt);
 	margin: var(--space-lg) 0;
 	-moz-tab-size: 2;
 	tab-size: 2;
@@ -391,12 +418,18 @@ code {
 
 :not(pre) > code {
 	background-color: var(--color-primary-light);
-	color: var(--color-primary-dark);
+	color: var(--color-primary);
 	padding: 0.2em 0.4em;
 	border-radius: var(--radius-sm);
 }
 
 /* Responsive utilities */
+@media (min-width: 1024px) {
+	.container {
+		padding: var(--space-lg) var(--space-xl);
+	}
+}
+
 @media (max-width: 768px) {
 	html {
 		font-size: 14px;


### PR DESCRIPTION
## Summary
- Extends the existing One Dark background into a full palette (One Dark / One Light), replacing scattered ad-hoc colors — including moving body text off pure white onto One Dark's actual foreground grey for easier long-form reading.
- Swaps Poppins for self-hosted IBM Plex Sans (body) + IBM Plex Mono (headings, nav, dates, tags, code) — one type family, two clear jobs.
- Widens the spacing scale and applies it more generously across sections, lists, and the CV timeline for a more spacious feel.
- Tightens border radii (24px → 16px max) and quiets shadows, especially in dark mode.
- Nav gets a wordmark to balance the previously flush-right layout, more vertical padding, and a sticky header.
- Extends the CV's existing timeline motif ("commit graph": mono dates, dot markers, amber highlight on the current role) to the blog list, so post dates read like commit history. Tags become git-branch-style mono chips.
- Shiki now renders with the One Dark Pro theme so code blocks match the rest of the site.
- Fixed two pre-existing bugs found along the way: a dangling `--color-bg-secondary` reference with no matching token (Project.astro, blog index), and a `Tags.astro` dark-mode override that ignored the user's explicit light/dark toggle choice when it disagreed with the OS preference.
- Added `AGENTS.md` with a standing instruction to run `/caveman-review` after any set of changes.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test:e2e` (Playwright smoke test) passes locally
- [x] Manually reviewed home, CV, projects, blog list, a blog post (incl. code block), and contact pages in both light and dark themes, desktop (1440px) and mobile (390px) viewports
- [x] Ran `/caveman-review` on the diff and fixed all 3 findings (a DRY duplication, a dead CSS token, and a WCAG 2.5.3 label-in-name accessibility issue)
- [ ] CI: waiting on Vercel preview + Playwright e2e run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAmgN2HbXQN3F9zd2eT15U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added active navigation states and a sticky site header with updated wordmark branding.
  * Added IBM Plex Sans and Mono typography across the site.
  * Added clearer current-role indicators and expandable responsibilities in the CV timeline.
  * Added colored-dot styling and pill-shaped tags.

* **Improvements**
  * Refreshed colors, spacing, shadows, buttons, cards, blog layouts, and code blocks for a more consistent visual design.
  * Added visible keyboard focus styling for improved accessibility.
  * Updated Markdown code highlighting to a new dark theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->