### PR TITLE
fix: keep CV badge text on one line

### DIFF
--- a/src/components/Tags.astro
+++ b/src/components/Tags.astro
@@ -22,6 +22,7 @@ const { tags } = Astro.props;
 	.tag {
 		display: inline-flex;
 		align-items: center;
+		flex-shrink: 0;
 		gap: 0.4rem;
 		background-color: var(--color-secondary-light);
 		color: var(--color-secondary);
@@ -30,6 +31,7 @@ const { tags } = Astro.props;
 		border: 1px solid var(--color-border);
 		font-family: var(--font-mono);
 		font-size: 0.75rem;
+		white-space: nowrap;
 	}
 
 	.tag::before {

--- a/src/components/Tags.astro
+++ b/src/components/Tags.astro
@@ -7,7 +7,13 @@ const { tags } = Astro.props;
 ---
 
 <ul class="tags">
-	{tags.map((t) => <li class="tag">{t}</li>)}
+	{
+		tags.map((t) => (
+			<li class="tag">
+				<span class="tag-label">{t}</span>
+			</li>
+		))
+	}
 </ul>
 
 <style>
@@ -31,7 +37,6 @@ const { tags } = Astro.props;
 		border: 1px solid var(--color-border);
 		font-family: var(--font-mono);
 		font-size: 0.75rem;
-		white-space: nowrap;
 	}
 
 	.tag::before {
@@ -41,5 +46,18 @@ const { tags } = Astro.props;
 		flex-shrink: 0;
 		border-radius: 50%;
 		background-color: currentColor;
+	}
+
+	.tag-label {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		/* Flex items default to min-width: auto (their full content width),
+		   which would make max-width powerless here — reset it first. */
+		min-width: 0;
+		/* Absolute cap (not %) so it truncates regardless of how the flex
+		   ancestors size themselves — comfortably above real tag/date
+		   content, just long enough to catch pathological input. */
+		max-width: 32ch;
 	}
 </style>


### PR DESCRIPTION
## Summary
- The date-range badge in the CV's sticky mobile job header (e.g. "Jul 20 - Jul 26") was wrapping mid-text when squeezed next to a long job title on narrow viewports.
- `Tags.astro`'s `.tag` pill had no `white-space: nowrap` / `flex-shrink: 0`, so as a flex child it would shrink and let its own text wrap. Fix keeps the badge intact on one line and lets the sibling title wrap instead (as it already did).

## Test plan
- [x] `pnpm test:e2e` passes locally
- [x] Verified visually at 390px width: CV sticky job header badge, blog tag chips (still wrap as a group, no internal text wrap)
- [x] Ran `/caveman-review` — no findings on this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAmgN2HbXQN3F9zd2eT15U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag display so labels remain on a single line and maintain their intended size.
  * Prevented tag items from shrinking in constrained layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->