### PR TITLE
fix: stop shrinking base font size on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -431,10 +431,6 @@ code {
 }
 
 @media (max-width: 768px) {
-	html {
-		font-size: 14px;
-	}
-
 	.container {
 		padding: 1.5rem;
 	}


### PR DESCRIPTION
## Summary
- Removed the mobile media query rule that dropped `html { font-size: 14px }` on screens ≤768px
- Since most type on the site is `rem`-based, that rule was scaling down all body text, tags, dates, and buttons on mobile — the opposite of intended, and much smaller than comparable sites (e.g. anthropic.com) on mobile

## Test plan
- [x] Verified blog list, single post, home, CV, and projects pages at a 390px mobile viewport — text is now clearly larger/readable, no overflow or awkward wrapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile text sizing by removing the smaller font-size override on narrow screens.
  * Preserved responsive container spacing and heading size adjustments for mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->