### PR TITLE
fix: pin theme toggle to top-right on mobile

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -88,8 +88,10 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 						>Projects</a
 					>
 					<a href="/blog" class={normalizedPathname.startsWith('/blog') ? 'active' : ''}>Blog</a>
-					<ThemeToggle />
 				</nav>
+				<div class="theme-toggle-slot">
+					<ThemeToggle />
+				</div>
 			</div>
 		</header>
 
@@ -130,9 +132,17 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 <!-- All styles are now in global.css -->
 <style>
 	.main-nav {
+		grid-area: nav;
 		display: flex;
 		gap: 1.5rem;
 		height: 44px;
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	.theme-toggle-slot {
+		grid-area: toggle;
+		display: flex;
 		align-items: center;
 	}
 
@@ -222,7 +232,14 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 			flex-wrap: wrap;
 		}
 
-		.header-container,
+		.header-container {
+			grid-template-columns: 1fr auto;
+			grid-template-areas:
+				'wordmark toggle'
+				'nav nav';
+			row-gap: 0.75rem;
+		}
+
 		.footer-container {
 			flex-direction: column;
 			gap: 0.75rem;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -265,12 +265,14 @@ li {
 	max-width: 800px;
 	margin: 0 auto;
 	padding: 0 var(--space-lg);
-	display: flex;
-	justify-content: space-between;
+	display: grid;
+	grid-template-columns: auto 1fr auto;
+	grid-template-areas: 'wordmark nav toggle';
 	align-items: center;
 }
 
 .wordmark {
+	grid-area: wordmark;
 	font-family: var(--font-heading);
 	font-weight: 600;
 	font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- The theme toggle lived inside `.main-nav`, so on mobile it wrapped and centered along with the nav links instead of staying in a fixed spot.
- `.header-container` is now a 3-area CSS grid (`wordmark` / `nav` / `toggle`) so the toggle has its own slot, independent of nav-link wrapping.
- Desktop layout is visually unchanged; mobile now anchors the toggle top-right, next to the wordmark, with nav links centered on their own row below.

## Test plan
- [x] Verified visually at 320/375/414/428px widths and 1440px desktop with a headless browser — toggle sits top-right on mobile, unchanged position on desktop
- [x] Toggled dark/light mode at mobile width — position holds, toggle still functions
- [x] `pnpm exec prettier --check` passes on changed files
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5ncxT3KHxemaziMXnEsEK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved header layout with clearer separation between branding, navigation, and the theme toggle.
  * Updated mobile navigation to use a two-row arrangement for improved usability on smaller screens.
  * Aligned navigation and theme controls consistently across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->