### PR TITLE
fix: add scroll shadow to sticky nav and collapse mobile header

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -126,6 +126,28 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 			import { initializeTransitions } from '../scripts/transitionEnhancer';
 			initializeTransitions();
 		</script>
+
+		<script>
+			let headerScrollHandler: (() => void) | null = null;
+
+			function setupHeaderScrollShadow() {
+				const header = document.querySelector<HTMLElement>('.site-header');
+				if (!header) return;
+
+				if (headerScrollHandler) {
+					window.removeEventListener('scroll', headerScrollHandler);
+				}
+
+				headerScrollHandler = () => {
+					header.classList.toggle('is-scrolled', window.scrollY > 4);
+				};
+
+				headerScrollHandler();
+				window.addEventListener('scroll', headerScrollHandler, { passive: true });
+			}
+
+			document.addEventListener('astro:page-load', setupHeaderScrollShadow);
+		</script>
 	</body>
 </html>
 
@@ -180,6 +202,11 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 		border-bottom: 1px solid var(--color-border);
 		padding: 1.25rem 0;
 		background-color: var(--color-background);
+		transition: box-shadow 0.2s ease;
+	}
+
+	.site-header.is-scrolled {
+		box-shadow: var(--shadow-md);
 	}
 
 	.footer-container {
@@ -238,6 +265,26 @@ const canonicalURL = new URL(cleanPath, Astro.site).href;
 				'wordmark toggle'
 				'nav nav';
 			row-gap: 0.75rem;
+			transition: row-gap 0.25s ease;
+		}
+
+		.wordmark,
+		.theme-toggle-slot {
+			max-height: 2.75rem;
+			overflow: hidden;
+			transition:
+				max-height 0.25s ease,
+				opacity 0.2s ease;
+		}
+
+		.site-header.is-scrolled .header-container {
+			row-gap: 0;
+		}
+
+		.site-header.is-scrolled .wordmark,
+		.site-header.is-scrolled .theme-toggle-slot {
+			max-height: 0;
+			opacity: 0;
 		}
 
 		.footer-container {


### PR DESCRIPTION
## Summary
- Adds a drop shadow to the sticky header once the page is scrolled, so it reads as distinct from page content
- On mobile, collapses the wordmark and theme toggle while scrolling, keeping only the compact nav bar sticky at the top

## Test plan
- [x] Verified via browser automation: desktop shadow appears/disappears correctly on scroll
- [x] Verified via browser automation: mobile header collapses wordmark/toggle on scroll, nav remains visible and sticky
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5ncxT3KHxemaziMXnEsEK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll-aware header behavior that changes its appearance as users move down the page.
  * Desktop headers now display a shadow after scrolling.
  * Mobile headers smoothly collapse the wordmark and theme toggle while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->