### PR TITLE
ci: replace wait-for-vercel-preview with vercel/wait-for-deployment-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
   test-preview:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: read
+      statuses: read
 
     steps:
       - uses: actions/checkout@v7
@@ -34,16 +38,18 @@ jobs:
 
       - name: Wait for Vercel deployment
         id: vercel-deployment
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
+        # Pinned to a commit SHA (no tagged releases yet) per the action's own guidance.
+        uses: vercel/wait-for-deployment-action@0e2b0c5c5cce31f1648108aeec56467187aca037
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 300
-          check_interval: 10
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          environment: preview
+          timeout: 300
+          check-interval: 10
 
       - name: Run Playwright tests
         run: pnpm test:e2e
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel-deployment.outputs.url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel-deployment.outputs.deployment-url }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Swap `patrickedqvist/wait-for-vercel-preview@v1.3.3` for the official `vercel/wait-for-deployment-action`
- Pinned to a commit SHA (`0e2b0c5`) since the action has no tagged releases yet — per the action's own README, which recommends pinning to a SHA
- Updated input names (`token`→`github-token`, `max_timeout`→`timeout`, `check_interval`→`check-interval`) and output name (`url`→`deployment-url`)
- Added `deployments: read` and `statuses: read` job permissions, which the new action needs to resolve the Vercel deployment status

## Test plan
- [ ] CI workflow run on this PR's branch successfully waits for the Vercel preview and runs Playwright tests against it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved preview deployment validation in the continuous integration process.
  * Automated browser tests now wait for the preview environment to be ready before running, improving test reliability.
  * Updated workflow permissions to follow least-privilege access practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->